### PR TITLE
task 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # nodejs-aws-be
 RS School AWS backend
 
-### task 6
+### task 7

--- a/authorization-service/.env.example
+++ b/authorization-service/.env.example
@@ -1,0 +1,1 @@
+vasiapupkin=TEST_PASSWORD

--- a/authorization-service/.eslintrc.json
+++ b/authorization-service/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "env": {
+    "browser": true,
+    "es6": true,
+    "es2022": true,
+    "node": true
+  },
+  "root": true,
+  "extends": [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "prettier"
+  ]
+}

--- a/authorization-service/basicAuthorizer.mjs
+++ b/authorization-service/basicAuthorizer.mjs
@@ -1,0 +1,47 @@
+const UNATHORIZED = "Unathorized";
+const EFFECT_ALLOW = "Allow";
+const EFFECT_DENY = "Deny";
+
+const generatePolicy = (principalId, effect = EFFECT_ALLOW, methodArn) => ({
+  principalId: principalId,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Action: "execute-api:Invoke",
+        Effect: effect,
+        Resource: methodArn,
+      },
+    ],
+  },
+});
+
+export const handler = async (event, _ctx, cb) => {
+  if (event["type"] != "TOKEN") {
+    cb(UNATHORIZED);
+  }
+
+  try {
+    const authToken = event.authorizationToken;
+    const authTokenArr = authToken.split(" ");
+    const authTokenDecoded = Buffer.from(authTokenArr[1], "base64");
+    const decodedTokenArr = authTokenDecoded.toString("utf-8").split(":");
+    const [tokenUsername, tokenPassword] = decodedTokenArr;
+    const userNameEncoded = tokenUsername
+      .replace(/_/g, "__")
+      .replace(/-/g, "_");
+
+    const envUserPassword = process.env[userNameEncoded];
+    const effect =
+      !envUserPassword || envUserPassword != tokenPassword
+        ? EFFECT_DENY
+        : EFFECT_ALLOW;
+
+    const policy = generatePolicy(authTokenArr[1], effect, event.methodArn);
+    cb(null, policy);
+  } catch (e) {
+    console.log("some error happens");
+    console.log(e);
+    cb(`${UNATHORIZED}: ${e?.message || "unknown error"}`);
+  }
+};

--- a/authorizationServiceStack.ts
+++ b/authorizationServiceStack.ts
@@ -1,0 +1,49 @@
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNode from "aws-cdk-lib/aws-lambda-nodejs";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+export class AuthorizationServiceStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const __dirname = fileURLToPath(new URL("./", import.meta.url));
+
+    const dotEnvConfig = dotenv.config();
+    if (dotEnvConfig.error) {
+      throw dotEnvConfig.error;
+    }
+
+    // get username for password TEST_PASSWORD from .env
+    const authData = Object.entries(process.env).find(
+      ([_, value]) => value == "TEST_PASSWORD"
+    ) || ["", ""];
+
+    const lambdaProps = {
+      memorySize: 1024,
+      timeout: cdk.Duration.seconds(5),
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: "handler",
+      bundling: {
+        format: lambdaNode.OutputFormat.ESM,
+      },
+      environment: {
+        ...(authData && {
+          [authData[0].replace(/_/g, "__").replace(/-/g, "_")]:
+            authData[1] as string,
+        }),
+      },
+    };
+
+    // lambdas:
+    new lambdaNode.NodejsFunction(this, "BasicAuthorizer", {
+      functionName: "basicAuthorizer",
+      entry: path.join(__dirname, "/authorization-service/basicAuthorizer.mjs"),
+      ...lambdaProps,
+    });
+  }
+}

--- a/cdkApp.ts
+++ b/cdkApp.ts
@@ -2,7 +2,10 @@
 import * as cdk from "aws-cdk-lib";
 import { ProductServiceStack } from "./productServiceStack";
 import { ImportServiceStack } from "./importServiceStack";
+import { AuthorizationServiceStack } from "./authorizationServiceStack";
 
 const app = new cdk.App();
+
 new ProductServiceStack(app, "ProductServiceStack"); // CF stack name
 new ImportServiceStack(app, "ImportServiceStack");
+new AuthorizationServiceStack(app, "AuthorizationServiceStack");

--- a/productServiceStack.ts
+++ b/productServiceStack.ts
@@ -36,12 +36,14 @@ export class ProductServiceStack extends cdk.Stack {
       },
     };
 
+    const lambdasSourcePath = path.join(__dirname, "/product-service");
+
     const getProductsListLambda = new lambdaNode.NodejsFunction(
       this,
       "ProductsListCDK",
       {
         functionName: "getProductsList",
-        entry: path.join(__dirname, "/productServiceCDK/getProductsList.mjs"),
+        entry: path.join(lambdasSourcePath, "/getProductsList.mjs"),
         ...commonLambdaProps,
       }
     );
@@ -52,7 +54,7 @@ export class ProductServiceStack extends cdk.Stack {
       "ProductsByIdCDK",
       {
         functionName: "getProductsById",
-        entry: path.join(__dirname, "/productServiceCDK/getProductsById.mjs"),
+        entry: path.join(lambdasSourcePath, "/getProductsById.mjs"),
         ...commonLambdaProps,
       }
     );
@@ -61,7 +63,7 @@ export class ProductServiceStack extends cdk.Stack {
       "ProductCreatePost",
       {
         functionName: "createProduct",
-        entry: path.join(__dirname, "/productServiceCDK/createProduct.mjs"),
+        entry: path.join(lambdasSourcePath, "/createProduct.mjs"),
         ...commonLambdaProps,
       }
     );
@@ -119,10 +121,7 @@ export class ProductServiceStack extends cdk.Stack {
       "ProductBatchCreateSQS",
       {
         functionName: "catalogBatchProcess",
-        entry: path.join(
-          __dirname,
-          "/productServiceCDK/catalogBatchProcess.mjs"
-        ),
+        entry: path.join(__dirname, "/product-service/catalogBatchProcess.mjs"),
         ...commonLambdaProps,
         environment: {
           ...commonLambdaProps.environment,


### PR DESCRIPTION
## Task 7- Authorization

**Point evaluation: 100**

## Main scope:
- `authorization-service` is added to the repo, has correct `basicAuthorizer` lambda and correct AWS CDK Stack
- Import Service AWS CDK Stack has authorizer configuration for the `importProductsFile` lambda. Request to the `importProductsFile` lambda should work only with correct `authorization_token` being decoded and checked by `basicAuthorizer` lambda. Response should be in 403 HTTP status if access is denied for this user (invalid `authorization_token`) and in 401 HTTP status if Authorization header is not provided.
- Client application is updated to send "Authorization: Basic `authorization_token`" header on import. Client should get `authorization_token` value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)

## Additional (optional) tasks
- **+30** - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the `nodejs-aws-fe-main/src/index.tsx` file.

FE app:
https://dujos7rix59g6.cloudfront.net/

FE: `Authorization: Basic` added
https://github.com/code-by/nodejs-aws-shop-react/pull/4/files

Import URL:
https://q089sbvz27.execute-api.eu-west-1.amazonaws.com/prod/import?name=file.csv

Displaying 401/403 errors in FE:
https://github.com/code-by/nodejs-aws-shop-react/blob/461eff88dc1042bd661efad37e441743ba870036/src/index.tsx#L12